### PR TITLE
improve ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,18 +1,14 @@
-name: CI
+name: CI Test
 
 on:
   push:
     branches: [ main ]
-    paths:
-      - 'cmd/*'
-      - 'pkg/*'
-      - 'tests/*'
+    paths-ignore:
+      - 'ceremony/**'
   pull_request:
     branches: [ main ]
-    paths:
-      - 'cmd/*'
-      - 'pkg/*'
-      - 'tests/*'
+    paths-ignore:
+      - 'ceremony/**'
 
 jobs:
   golangci:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,8 +21,6 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '1.16.4'
-      - name: deps
-        run: sudo apt-get update && sudo apt-get install -yq libpcsclite-dev
       - name: root
         run: wget https://developers.yubico.com/PIV/Introduction/piv-attestation-ca.pem
       - name: build

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,31 @@
+name: CI Validate
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'ceremony/**'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'ceremony/**'
+
+jobs:  
+  validate:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+      - run: echo "REPO=$(git diff --name-only ${{ github.event.before }}..${{ github.event.after }} | grep .json | cut -d/ -f 1-2)" >> $GITHUB_ENV
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16.4'
+      - name: deps
+        run: sudo apt-get update && sudo apt-get install -yq libpcsclite-dev
+      - name: root
+        run: wget https://developers.yubico.com/PIV/Introduction/piv-attestation-ca.pem
+      - name: build
+        run: go build -o verify ./cmd/verify/
+      - name: verify
+        run: ./verify --root piv-attestation-ca.pem --repository $REPO


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Adds a validation CI action that only runs on changes in ceremony/
Simplifies the validaiton script since the key-directory arg is redundant and predictable with the $REPO argument
Renames the test action to test 

In a second TODO i'll replace the validation build with a precompiled binary
