### PR TITLE
fix re-writing key ids

### DIFF
--- a/cmd/tuf/app/sign.go
+++ b/cmd/tuf/app/sign.go
@@ -278,7 +278,7 @@ func SignMeta(ctx context.Context, store tuf.LocalStore, name string, signer sig
 				})
 			} else {
 				sigs = append(sigs, data.Signature{
-					KeyID: id,
+					KeyID: entry.KeyID,
 				})
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
